### PR TITLE
Redirect Apache and Shibboleth logs to docker logs via console output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,11 @@ RUN test -d /var/run/lock || mkdir -p /var/run/lock \
     && mkdir /etc/shib-volume/ \
     && mkdir /etc/shibboleth-ds/idp_metadata/ \
     && ln -s /etc/shibboleth/sp-key.pem /etc/shib-volume/sp-key.pem \
-    && ln -s /etc/shibboleth/sp-cert.pem /etc/shib-volume/sp-cert.pem
+    && ln -s /etc/shibboleth/sp-cert.pem /etc/shib-volume/sp-cert.pem \
+    && sed -i -e 's/^ErrorLog .*$/ErrorLog \/proc\/self\/fd\/2/' -e 's/^    CustomLog .* combined$/    CustomLog \/proc\/self\/fd\/1 combined/' /etc/httpd/conf/httpd.conf \
+    && sed -i -e 's/^ErrorLog .*$/ErrorLog \/proc\/self\/fd\/2/' -e 's/^CustomLog .* \\$/CustomLog \/proc\/self\/fd\/1 \\/' -e 's/^TransferLog .*$/TransferLog \/proc\/self\/fd\/1/' /etc/httpd/conf.d/ssl.conf \
+    && sed -i -e 's/^    clockSkew/    logger="console.logger" clockSkew/' /etc/shibboleth/shibboleth2.xml \
+    && sed -i -e '8ilog4j.category.Shibboleth-TRANSACTION=INFO\nlog4j.category.XMLTooling.Signature.Debugger=INFO' /etc/shibboleth/console.logger
 
 EXPOSE 80 443
 


### PR DESCRIPTION
I first tried to employ rsyslogd inside container to redirect logs directly to host's syslogd. I couldn't however get rsyslogd to work in CentOS container (even though it works in eg. Ubuntu container). Thus, I changed all Apache & Shibboleth logging to happen to stdout & stderr so that they will work like the rest of containers.